### PR TITLE
LPS-135072 Accessibility fix, remove IE7 CSS rules starting with *

### DIFF
--- a/css/font-awesome.css
+++ b/css/font-awesome.css
@@ -41,7 +41,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em;
 }
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
@@ -268,11 +267,9 @@ a [class*=" icon-"] {
   height: 100%;
   font-size: 1em;
   line-height: inherit;
-  *line-height: 2em;
 }
 .icon-stack .icon-stack-base {
   font-size: 2em;
-  *line-height: 1em;
 }
 /* Animated rotating icon */
 .icon-spin {

--- a/less/mixins-alloy.less
+++ b/less/mixins-alloy.less
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 .border-radius(@radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: @top-font-size;
       line-height: inherit;
-      *line-height: @height;
     }
     .icon-stack-base {
       font-size: @base-font-size;
-      *line-height: @height / @base-font-size;
     }
   }
 }

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 .border-radius(@radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: @top-font-size;
       line-height: inherit;
-      *line-height: @height;
     }
     .icon-stack-base {
       font-size: @base-font-size;
-      *line-height: @height / @base-font-size;
     }
   }
 }

--- a/scss/_mixins-alloy.scss
+++ b/scss/_mixins-alloy.scss
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 @mixin border-radius($radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: $top-font-size;
       line-height: inherit;
-      *line-height: $height;
     }
     .icon-stack-base {
       font-size: $base-font-size;
-      *line-height: #{$height / $base-font-size}em;
     }
   }
 }

--- a/src/assets/font-awesome/less/mixins-alloy.less
+++ b/src/assets/font-awesome/less/mixins-alloy.less
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 .border-radius(@radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: @top-font-size;
       line-height: inherit;
-      *line-height: @height;
     }
     .icon-stack-base {
       font-size: @base-font-size;
-      *line-height: @height / @base-font-size;
     }
   }
 }

--- a/src/assets/font-awesome/less/mixins.less
+++ b/src/assets/font-awesome/less/mixins.less
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 .border-radius(@radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: @top-font-size;
       line-height: inherit;
-      *line-height: @height;
     }
     .icon-stack-base {
       font-size: @base-font-size;
-      *line-height: @height / @base-font-size;
     }
   }
 }

--- a/src/assets/font-awesome/scss/_mixins-alloy.scss
+++ b/src/assets/font-awesome/scss/_mixins-alloy.scss
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 @mixin border-radius($radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: $top-font-size;
       line-height: inherit;
-      *line-height: $height;
     }
     .icon-stack-base {
       font-size: $base-font-size;
-      *line-height: #{$height / $base-font-size}em;
     }
   }
 }

--- a/src/assets/font-awesome/scss/_mixins.scss
+++ b/src/assets/font-awesome/scss/_mixins.scss
@@ -12,7 +12,6 @@
   font-style: normal;
   text-decoration: inherit;
   -webkit-font-smoothing: antialiased;
-  *margin-right: .3em; // fixes ie7 issues
 }
 
 @mixin border-radius($radius) {
@@ -38,11 +37,9 @@
       height: 100%;
       font-size: $top-font-size;
       line-height: inherit;
-      *line-height: $height;
     }
     .icon-stack-base {
       font-size: $base-font-size;
-      *line-height: #{$height / $base-font-size}em;
     }
   }
 }


### PR DESCRIPTION
For more details and steps to reproduce, check LPS-135072.

We have a client on 7.2.x that is using this tool https://administracionelectronica.gob.es/comunidades/verPestanaMas.htm?idComunidad=accesibilidad#.YKZABKj7SHv to verify the validity of their website (I explained more about this tool on LPS-133314) 
The tool seems to not like this CSS rules that starts with * made specially for fixing IE7 issues:
*margin-right: .3em; 
*line-height: 2em;
*line-height: 1em;

I tested on 7.2.x branch with yarn link and I could see these rules are coming from the changed file on this PR.

Please review. 