### PR TITLE
Switch less to a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
       "url": "http://opensource.org/licenses/mit-license.html"
     }
   ],
-  "dependencies": {
+  "devDependencies": {
     "less": "1.4.1"
   }
 }


### PR DESCRIPTION
When users include liferay-font-awesome as a dependency:

```bash
mkdir test
cd test
echo '{ "dependencies": { "liferay-font-awesome": "3.4.1" } }' > package.json
npm install
```

Running npm install results in the following warning:

```
found 1 moderate severity vulnerability
  run `npm audit fix` to fix them, or `npm audit` for details
```

In a Slack conversation, it was recommended that we switch it to a dev dependency to resolve the issue (though I don't know whether this will actually work).

https://liferay.slack.com/archives/CNBG06JS3/p1628149835034700

Sending this to the master branch rather than a WIP branch due to changes that were made to the 4.0.0-wip branch being incompatible with a new release of 3.4.x.